### PR TITLE
fix: allow global config files with a name other than "osnap.config.yaml"

### DIFF
--- a/lib/OSnap_Config/OSnap_Config_Global.ml
+++ b/lib/OSnap_Config/OSnap_Config_Global.ml
@@ -63,9 +63,7 @@ module YAML = struct
       |> Result.map (Option.value ~default:8)
       |> Result.map (max 1)
     in
-    let root_path =
-      String.sub path 0 (String.length path - String.length "osnap.config.yaml")
-    in
+    let root_path = Filename.dirname path in
     let* test_pattern =
       yaml
       |> OSnap_Config_Utils.YAML.get_string_option "testPattern"
@@ -243,9 +241,7 @@ module JSON = struct
       | Yojson.Basic.Util.Type_error (message, _) ->
         Result.error (OSnap_Response.Config_Parse_Error (message, Some path))
     in
-    let root_path =
-      String.sub path 0 (String.length path - String.length "osnap.config.json")
-    in
+    let root_path = Filename.dirname path in
     let* ignore_patterns =
       try
         json

--- a/lib/OSnap_Paths.ml
+++ b/lib/OSnap_Paths.ml
@@ -1,20 +1,20 @@
 let get_snapshot_root_path (config : OSnap_Config.Types.global) =
-  config.root_path ^ config.snapshot_directory
+  Filename.concat config.root_path config.snapshot_directory
 ;;
 
 let get_base_images_dir (config : OSnap_Config.Types.global) =
   let base_path = get_snapshot_root_path config in
-  base_path ^ "/__base_images__"
+  Filename.concat base_path "__base_images__"
 ;;
 
 let get_updated_dir (config : OSnap_Config.Types.global) =
   let base_path = get_snapshot_root_path config in
-  base_path ^ "/__updated__"
+  Filename.concat base_path "__updated__"
 ;;
 
 let get_diff_dir (config : OSnap_Config.Types.global) =
   let base_path = get_snapshot_root_path config in
-  base_path ^ "/__diff__"
+  Filename.concat base_path "__diff__"
 ;;
 
 type t =


### PR DESCRIPTION
fixes #26 