### PR TITLE
chore: add info and debug logs

### DIFF
--- a/bin/Main.ml
+++ b/bin/Main.ml
@@ -2,6 +2,11 @@ open Cmdliner;;
 
 Fmt.set_style_renderer Fmt.stdout `Ansi_tty
 
+let setup_log =
+  let open Term in
+  const OSnap.Logger.init $ Fmt_cli.style_renderer () $ Logs_cli.level ()
+;;
+
 let print_warning msg =
   let printer = Fmt.pr "%a @." (Fmt.styled `Yellow Fmt.string) in
   Printf.ksprintf printer msg
@@ -119,7 +124,7 @@ let default_cmd =
     let open Arg in
     value & opt (some int) None & info [ "p"; "parallelism" ] ~doc
   in
-  let exec noCreate noOnly noSkip parallelism config_path =
+  let exec noCreate noOnly noSkip parallelism config_path () =
     let ( let*? ) = Result.bind in
     let run ~sw ~env =
       let*? t = OSnap.setup ~sw ~env ~config_path ~noCreate ~noOnly ~noSkip in
@@ -153,7 +158,7 @@ let default_cmd =
     @@ fun _ -> Eio.Switch.run @@ fun sw -> run ~sw ~env
   in
   ( (let open Term in
-     const exec $ noCreate $ noOnly $ noSkip $ parallelism $ config)
+     const exec $ noCreate $ noOnly $ noSkip $ parallelism $ config $ setup_log)
   , Cmd.info
       "osnap"
       ~man:

--- a/bin/dune
+++ b/bin/dune
@@ -6,6 +6,7 @@
  (ocamlopt_flags -O3)
  (libraries
   OSnap
+  OSnap_Logger
   cmdliner
   mirage-crypto-rng
   mirage-crypto-rng.unix

--- a/dune-project
+++ b/dune-project
@@ -31,6 +31,7 @@
   fileutils
   fmt
   libspng
+  logs
   odiff-core
   re
   uri

--- a/lib/OSnap.ml
+++ b/lib/OSnap.ml
@@ -2,6 +2,7 @@ module Config = OSnap_Config
 module Browser = OSnap_Browser
 module Test = OSnap_Test
 open OSnap_Utils
+module Logger = OSnap_Logger
 
 type t =
   { config : Config.Types.global
@@ -13,11 +14,15 @@ type t =
 let setup ~sw ~env ~noCreate ~noOnly ~noSkip ~config_path =
   let ( let*? ) = Result.bind in
   let open Config.Types in
+  let debug = Logger.info ~header:"SETUP" in
   let start_time = Eio.Time.now (Eio.Stdenv.clock env) in
   let*? config = Config.Global.init ~env ~config_path in
+  debug "initializing folder structure";
   let () = OSnap_Paths.init_folder_structure config in
+  debug "getting snapshow dir";
   let snapshot_dir = OSnap_Paths.get_base_images_dir config in
   let*? all_tests = Config.Test.init config in
+  debug (Printf.sprintf "found %i tests" (List.length all_tests));
   let*? only_tests, tests =
     all_tests
     |> ResultList.traverse (fun test ->
@@ -58,6 +63,8 @@ let setup ~sw ~env ~noCreate ~noOnly ~noSkip ~config_path =
     | [], tests -> tests
     | only_tests, _ -> only_tests
   in
+  debug (Printf.sprintf "found %i tests to run" (List.length tests_to_run));
+  debug "setting test priority";
   let tests_to_run =
     tests_to_run
     |> List.fast_sort (fun (_test, _size, exists1) (_test, _size, exists2) ->
@@ -71,10 +78,12 @@ let run ~env t =
   Eio.Switch.run
   @@ fun sw ->
   let open Config.Types in
+  let debug = Logger.info ~header:"RUN" in
   let { tests_to_run; config; start_time; browser } = t in
   Test.Printer.Progress.set_total (List.length tests_to_run);
   let domain_count = Domain.recommended_domain_count () in
   let parallelism = domain_count * 3 in
+  debug (Printf.sprintf "creating pool of %i runners" parallelism);
   let test_stream = Eio.Stream.create 0 in
   let browser_pool =
     Eio.Pool.create
@@ -82,6 +91,7 @@ let run ~env t =
       (fun () -> Browser.Target.make browser)
       ~validate:(fun target -> Result.is_ok target)
   in
+  debug "Assigning tests to runners...";
   for _ = 1 to parallelism do
     Eio.Fiber.fork_daemon ~sw (fun () ->
       let rec aux () =
@@ -95,6 +105,7 @@ let run ~env t =
       in
       aux ())
   done;
+  debug "Waiting for test results to come back";
   let rec run_test test =
     let reply, resolve_reply = Eio.Promise.create () in
     Eio.Stream.add test_stream (test, resolve_reply);
@@ -126,6 +137,7 @@ let run ~env t =
            ; result = None
            }
   in
+  debug "Tests were run to completion. Calculating final stats.";
   let end_time = Eio.Time.now (Eio.Stdenv.clock env) in
   let seconds = end_time -. start_time in
   Test.Printer.stats ~seconds test_results

--- a/lib/OSnap.mli
+++ b/lib/OSnap.mli
@@ -1,3 +1,4 @@
+module Logger = OSnap_Logger
 module Config = OSnap_Config
 module Browser = OSnap_Browser
 

--- a/lib/OSnap_Browser/dune
+++ b/lib/OSnap_Browser/dune
@@ -2,6 +2,7 @@
  (name OSnap_Browser)
  (libraries
   OSnap_Utils
+  OSnap_Logger
   OSnap_Websocket
   unix
   fmt

--- a/lib/OSnap_Config/dune
+++ b/lib/OSnap_Config/dune
@@ -1,3 +1,3 @@
 (library
  (name OSnap_Config)
- (libraries OSnap_Utils eio eio.unix unix re fileutils yaml))
+ (libraries OSnap_Logger OSnap_Utils eio eio.unix unix re fileutils yaml))

--- a/lib/OSnap_Logger/OSnap_Logger.ml
+++ b/lib/OSnap_Logger/OSnap_Logger.ml
@@ -1,0 +1,21 @@
+let src = Logs.Src.create "osnap"
+
+let init style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.Src.set_level src level;
+  Logs.set_reporter (Logs_fmt.reporter ())
+;;
+
+let debug ~header message =
+  Logs.debug ~src (fun log -> log ~header "%a" (Fmt.styled `Faint Fmt.string) message)
+;;
+
+let info ~header message = Logs.info ~src (fun log -> log ~header "%a" Fmt.string message)
+
+let warn ~header message =
+  Logs.warn ~src (fun log -> log ~header "%a" (Fmt.styled `Yellow Fmt.string) message)
+;;
+
+let error ~header message =
+  Logs.err ~src (fun log -> log ~header "%a" (Fmt.styled `Red Fmt.string) message)
+;;

--- a/lib/OSnap_Logger/dune
+++ b/lib/OSnap_Logger/dune
@@ -1,0 +1,3 @@
+(library
+ (name OSnap_Logger)
+ (libraries fmt fmt.cli fmt.tty logs logs.cli logs.fmt))

--- a/lib/OSnap_Websocket/dune
+++ b/lib/OSnap_Websocket/dune
@@ -1,6 +1,7 @@
 (library
  (name OSnap_Websocket)
  (libraries
+  OSnap_Logger
   OSnap_Utils
   conduit-lwt
   conduit-lwt-unix

--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,7 @@
   OSnap_Test
   OSnap_Paths
   OSnap_Utils
+  OSnap_Logger
   OSnap_Config
   OSnap_Browser
   unix

--- a/osnap.opam
+++ b/osnap.opam
@@ -21,6 +21,7 @@ depends: [
   "fileutils"
   "fmt"
   "libspng"
+  "logs"
   "odiff-core"
   "re"
   "uri"


### PR DESCRIPTION
May be enabled by passing -v[v] to osnap.

`osnap -v` = Info Logs
`osnap -vv` = Debug Logs