### PR TITLE
fix: add missing libraries to debian image

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,10 +1,12 @@
 FROM debian:bookworm
 
 RUN apt-get update && \
-	apt-get install -y libnss3
+	apt-get install -y libnss3 libexpat-dev netbase
 
 COPY --from=chromedp/headless-shell:133.0.6943.142 /headless-shell /root/osnap_chromium_1402768/chrome-headless-shell-linux64
-RUN mv /root/osnap_chromium_1402768/chrome-headless-shell-linux64/headless-shell /root/osnap_chromium_1402768/chrome-headless-shell-linux64/chrome-headless-shell
+RUN mv \
+	/root/osnap_chromium_1402768/chrome-headless-shell-linux64/headless-shell \
+	/root/osnap_chromium_1402768/chrome-headless-shell-linux64/chrome-headless-shell
 
 COPY _release /usr/local
 

--- a/docker/Dockerfile.node-lts
+++ b/docker/Dockerfile.node-lts
@@ -1,7 +1,7 @@
 FROM node:lts-bookworm
 
 RUN apt-get update && \
-	apt-get install -y libnss3
+	apt-get install -y libnss3 libexpat-dev netbase
 
 COPY --from=chromedp/headless-shell:133.0.6943.142 /headless-shell /root/osnap_chromium_1402768/chrome-headless-shell-linux64
 RUN mv \


### PR DESCRIPTION
...and to be safe also to the node-lts image

- `libexpat` is required by chromium
- `netbase` installs `/etc/services` which is required for scheme resolution

fixes #50 