### PR TITLE
feat: add config to ignore certificate errors

### DIFF
--- a/lib/OSnap.ml
+++ b/lib/OSnap.ml
@@ -88,7 +88,7 @@ let run ~env t =
   let browser_pool =
     Eio.Pool.create
       parallelism
-      (fun () -> Browser.Target.make browser)
+      (fun () -> Browser.Target.make ~config browser)
       ~validate:(fun target -> Result.is_ok target)
   in
   debug "Assigning tests to runners...";

--- a/lib/OSnap_Browser/OSnap_Browser_Target.ml
+++ b/lib/OSnap_Browser/OSnap_Browser_Target.ml
@@ -6,7 +6,7 @@ type target =
   ; sessionId : Cdp.Types.Target.SessionID.t
   }
 
-let enable_events t =
+let enable_events ~(config : OSnap_Config.Types.global) t =
   let ( let*? ) = Result.bind in
   let open Cdp.Commands in
   let sessionId = t.sessionId in
@@ -72,10 +72,27 @@ let enable_events t =
     in
     Option.to_result response.Response.result ~none:error
   in
+  let*? _ =
+    let open Security.SetIgnoreCertificateErrors in
+    let response =
+      Request.make
+        ~sessionId
+        ~params:(Params.make ~ignore:config.ignore_certificate_errors ())
+      |> Websocket.send
+      |> Response.parse
+    in
+    let error =
+      response.Response.error
+      |> Option.map (fun (error : Response.error) ->
+        `OSnap_CDP_Protocol_Error error.message)
+      |> Option.value ~default:(`OSnap_CDP_Protocol_Error "")
+    in
+    Option.to_result response.Response.result ~none:error
+  in
   Result.ok ()
 ;;
 
-let make browser =
+let make ~config browser =
   let ( let*? ) = Result.bind in
   let*? { targetId } =
     let open Cdp.Commands.Target.CreateTarget in
@@ -115,6 +132,6 @@ let make browser =
     Option.to_result response.Response.result ~none:error
   in
   let t = { targetId; sessionId } in
-  let*? () = enable_events t in
+  let*? () = enable_events ~config t in
   Result.ok t
 ;;

--- a/lib/OSnap_Browser/OSnap_Browser_Target.mli
+++ b/lib/OSnap_Browser/OSnap_Browser_Target.mli
@@ -4,5 +4,6 @@ type target =
   }
 
 val make
-  :  OSnap_Browser_Types.t
+  :  config:OSnap_Config.Types.global
+  -> OSnap_Browser_Types.t
   -> (target, [> `OSnap_CDP_Protocol_Error of string ]) Result.t

--- a/lib/OSnap_Browser/dune
+++ b/lib/OSnap_Browser/dune
@@ -1,6 +1,7 @@
 (library
  (name OSnap_Browser)
  (libraries
+  OSnap_Config
   OSnap_Utils
   OSnap_Logger
   OSnap_Websocket

--- a/lib/OSnap_Config/OSnap_Config_Global.ml
+++ b/lib/OSnap_Config/OSnap_Config_Global.ml
@@ -132,6 +132,11 @@ module YAML = struct
     let* expected_response_code =
       yaml |> OSnap_Config_Utils.YAML.get_int_option ~path "expectedResponseCode"
     in
+    let* ignore_certificate_errors =
+      yaml
+      |> OSnap_Config_Utils.YAML.get_bool_option ~path "ignoreCertificateErrors"
+      |> Result.map (Option.value ~default:false)
+    in
     let duplicates =
       default_sizes
       |> List.filter (fun (s : OSnap_Config_Types.size) -> Option.is_some s.name)
@@ -158,6 +163,7 @@ module YAML = struct
         ; parallelism
         ; additional_headers
         ; expected_response_code
+        ; ignore_certificate_errors
         }
   ;;
 end

--- a/lib/OSnap_Config/OSnap_Config_Types.ml
+++ b/lib/OSnap_Config/OSnap_Config_Types.ml
@@ -56,4 +56,5 @@ type global =
   ; parallelism : int option
   ; additional_headers : additional_headers
   ; expected_response_code : int option
+  ; ignore_certificate_errors : bool
   }

--- a/website/docs/Setup/configuration.md
+++ b/website/docs/Setup/configuration.md
@@ -163,6 +163,16 @@ A record of additional headers to send with each request.
 
 The expected status code of the response. The test will fail, when the expected code does not match the returned one.
 
+---
+
+### Ignore Certificate Errors
+
+- **Key**: `ignoreCertificateErrors`
+- **Required**: `false`
+- **Type**: `bool`
+
+If true, the browser will not show the error page for invalid https certificates.
+
 ## Example
 
 **A full example of a global config file:**
@@ -188,6 +198,7 @@ additionalHttpHeaders:
   Authorization: "Bearer mytoken123"
 
 expectedResponseCode: 200
+ignoreCertificateErrors: true
 
 diffPixelColor:
   r: 209


### PR DESCRIPTION
Thanks for this great tool @eWert-Online, I've found it really useful.

For a current project, we need to do some visual regression testing across some test sites that don't have valid SSL certificates, so having an option to ignore them is useful.

This PR introduces a new config option, `ignoreCertificateErrors` a boolean that defaults to `false`.

I'm completely new to OCaml so I welcome any feedback and understand if you would prefer not to include this new configuration.